### PR TITLE
Add package.json metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "MMM-Profilepicture",
+  "version": "1.0.0",
+  "description": "MagicMirror² module to set a background picture for the current profile.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Snille/MMM-Profilepicture.git"
+  },
+  "keywords": [
+    "magicmirror",
+    "magicmirror2",
+    "MagicMirror²",
+    "profile",
+    "background",
+    "module"
+  ],
+  "author": "Erik Pettersson",
+  "license": "MIT"
+}


### PR DESCRIPTION
Adds a minimal package.json (metadata only) so MagicMirror module tooling can index the module and so the module analysis stops flagging missing package.json.\n\nNo functional changes.